### PR TITLE
Replace DeepSeek fine-tuned slot with Llama 3.1 8B + DPO LoRA adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 OPENAI_API_KEY=your_openai_api_key_here
 MINERU_API_KEY=your_mineru_api_key_here
 RUNPOD_API_KEY=your_runpod_api_key_here
+HF_TOKEN=your_huggingface_token_here
 
 # Small LLM Configuration (RunPod vLLM)
 SMALL_LLM_SERVICE_URL=https://api.runpod.ai/v2/<small_llm_endpoint_id>/openai
@@ -19,8 +20,13 @@ EMBEDDING_DIMENSIONS=1536
 
 # Fine-Tuned Model Configuration (RunPod vLLM)
 FINE_TUNED_MODEL_SERVICE_URL=https://api.runpod.ai/v2/<fine_tuned_endpoint_id>/openai
-FINE_TUNED_MODEL_NAME=deepseek-ai/DeepSeek-R1-Distill-Qwen-7B
+FINE_TUNED_MODEL_NAME=dpo-8b
 FINE_TUNED_MODEL_API_KEY=your_runpod_api_key
+
+# Fine-Tuned Model (LoRA adapter)
+FINE_TUNED_BASE_MODEL=meta-llama/Meta-Llama-3.1-8B-Instruct
+FINE_TUNED_ADAPTER_REPO=jadshaker/tutorbot-dpo-models
+FINE_TUNED_ADAPTER_NAME=dpo-8b
 
 # Large LLM Configuration (OpenAI)
 LARGE_LLM_MODEL_NAME=gpt-4o-mini

--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,6 @@
 OPENAI_API_KEY=your_openai_api_key_here
 MINERU_API_KEY=your_mineru_api_key_here
 RUNPOD_API_KEY=your_runpod_api_key_here
-HF_TOKEN=your_huggingface_token_here
 
 # Small LLM Configuration (RunPod vLLM)
 SMALL_LLM_SERVICE_URL=https://api.runpod.ai/v2/<small_llm_endpoint_id>/openai

--- a/.env.example
+++ b/.env.example
@@ -20,13 +20,8 @@ EMBEDDING_DIMENSIONS=1536
 
 # Fine-Tuned Model Configuration (RunPod vLLM)
 FINE_TUNED_MODEL_SERVICE_URL=https://api.runpod.ai/v2/<fine_tuned_endpoint_id>/openai
-FINE_TUNED_MODEL_NAME=dpo-8b
+FINE_TUNED_MODEL_NAME=jadshaker/tutorbot-dpo-merged
 FINE_TUNED_MODEL_API_KEY=your_runpod_api_key
-
-# Fine-Tuned Model (LoRA adapter)
-FINE_TUNED_BASE_MODEL=meta-llama/Meta-Llama-3.1-8B-Instruct
-FINE_TUNED_ADAPTER_REPO=jadshaker/tutorbot-dpo-models
-FINE_TUNED_ADAPTER_NAME=dpo-8b
 
 # Large LLM Configuration (OpenAI)
 LARGE_LLM_MODEL_NAME=gpt-4o-mini

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -52,7 +52,7 @@ jobs:
           EMBEDDING_DIMENSIONS=1536
 
           FINE_TUNED_MODEL_SERVICE_URL=https://api.runpod.ai/v2/${FINE_TUNED_ENDPOINT_ID}/openai
-          FINE_TUNED_MODEL_NAME=deepseek-ai/DeepSeek-R1-Distill-Qwen-7B
+          FINE_TUNED_MODEL_NAME=jadshaker/tutorbot-dpo-merged
           FINE_TUNED_MODEL_API_KEY=$RUNPOD_API_KEY
           FINE_TUNED_MODEL_TEMPERATURE=0.7
           FINE_TUNED_MODEL_TOP_P=0.9
@@ -112,7 +112,7 @@ jobs:
           curl -s -m 300 "https://api.runpod.ai/v2/${FINE_TUNED_ENDPOINT_ID}/openai/v1/chat/completions" \
             -H "Authorization: Bearer $RUNPOD_API_KEY" \
             -H "Content-Type: application/json" \
-            -d '{"model":"deepseek-ai/DeepSeek-R1-Distill-Qwen-7B","messages":[{"role":"user","content":"hi"}]}' > /dev/null &
+            -d '{"model":"jadshaker/tutorbot-dpo-merged","messages":[{"role":"user","content":"hi"}]}' > /dev/null &
           PID3=$!
 
           # Wait for all warmup requests to complete
@@ -163,7 +163,7 @@ jobs:
         env:
           SMALL_LLM_MODEL_NAME: deepseek-ai/DeepSeek-R1-Distill-Qwen-7B
           REFORMULATOR_LLM_MODEL_NAME: deepseek-ai/DeepSeek-R1-Distill-Qwen-7B
-          FINE_TUNED_MODEL_NAME: deepseek-ai/DeepSeek-R1-Distill-Qwen-7B
+          FINE_TUNED_MODEL_NAME: jadshaker/tutorbot-dpo-merged
           LARGE_LLM_MODEL_NAME: gpt-4o-mini
         run: |
           echo "Running all tests..."

--- a/commands/pod.py
+++ b/commands/pod.py
@@ -68,29 +68,16 @@ def _build_startup_cmd() -> str:
     """Build docker startup command for 3 vLLM instances.
 
     Each instance is pinned to its own GPU via CUDA_VISIBLE_DEVICES.
-    The fine-tuned model slot uses LoRA (Llama base + adapter from HF).
+    Model names are read from .env so each instance serves the right model.
     """
     cmds = []
     for model_var, _, _, port, gpu_idx in SERVICES:
-        if model_var == "FINE_TUNED_MODEL_NAME":
-            base = _read_env_var("FINE_TUNED_BASE_MODEL")
-            repo = _read_env_var("FINE_TUNED_ADAPTER_REPO")
-            adapter = _read_env_var("FINE_TUNED_ADAPTER_NAME")
-            cmds.append(
-                f"hf download {repo} --local-dir /workspace/adapter && "
-                f"hf download {base} --local-dir /workspace/base-model && "
-                f"CUDA_VISIBLE_DEVICES={gpu_idx} vllm serve /workspace/base-model "
-                f"--enable-lora --lora-modules {adapter}=/workspace/adapter/{adapter} "
-                f"--port {port} --gpu-memory-utilization 0.9 "
-                f"--max-model-len 4096 --max-lora-rank 64 --host 0.0.0.0 --api-key {VLLM_API_KEY} &"
-            )
-        else:
-            model = _read_env_var(model_var)
-            cmds.append(
-                f"CUDA_VISIBLE_DEVICES={gpu_idx} vllm serve {model} "
-                f"--port {port} --gpu-memory-utilization 0.9 "
-                f"--max-model-len 4096 --host 0.0.0.0 --api-key {VLLM_API_KEY} &"
-            )
+        model = _read_env_var(model_var)
+        cmds.append(
+            f"CUDA_VISIBLE_DEVICES={gpu_idx} vllm serve {model} "
+            f"--port {port} --gpu-memory-utilization 0.9 "
+            f"--max-model-len 4096 --host 0.0.0.0 --api-key {VLLM_API_KEY} &"
+        )
     vllm_starts = " ".join(cmds)
     script = f"export HF_HOME=/root/.cache/huggingface && {vllm_starts} wait"
     # Escaped double quotes — the RunPod SDK wraps docker_args in "..." for GraphQL

--- a/commands/pod.py
+++ b/commands/pod.py
@@ -177,7 +177,6 @@ def start() -> None:
                 container_disk_in_gb=100,
                 ports=",".join(f"{p}/http" for _, _, _, p, _ in SERVICES),
                 docker_args=_build_startup_cmd(),
-                env={"HF_TOKEN": _read_env_var("HF_TOKEN")},
             )
             used_gpu = gpu
             print(f"  Created: {pod['id']}")

--- a/commands/pod.py
+++ b/commands/pod.py
@@ -68,16 +68,29 @@ def _build_startup_cmd() -> str:
     """Build docker startup command for 3 vLLM instances.
 
     Each instance is pinned to its own GPU via CUDA_VISIBLE_DEVICES.
-    Model names are read from .env so each instance serves the right model.
+    The fine-tuned model slot uses LoRA (Llama base + adapter from HF).
     """
     cmds = []
     for model_var, _, _, port, gpu_idx in SERVICES:
-        model = _read_env_var(model_var)
-        cmds.append(
-            f"CUDA_VISIBLE_DEVICES={gpu_idx} vllm serve {model} "
-            f"--port {port} --gpu-memory-utilization 0.9 "
-            f"--max-model-len 4096 --host 0.0.0.0 --api-key {VLLM_API_KEY} &"
-        )
+        if model_var == "FINE_TUNED_MODEL_NAME":
+            base = _read_env_var("FINE_TUNED_BASE_MODEL")
+            repo = _read_env_var("FINE_TUNED_ADAPTER_REPO")
+            adapter = _read_env_var("FINE_TUNED_ADAPTER_NAME")
+            cmds.append(
+                f"hf download {repo} --local-dir /workspace/adapter && "
+                f"hf download {base} --local-dir /workspace/base-model && "
+                f"CUDA_VISIBLE_DEVICES={gpu_idx} vllm serve /workspace/base-model "
+                f"--enable-lora --lora-modules {adapter}=/workspace/adapter/{adapter} "
+                f"--port {port} --gpu-memory-utilization 0.9 "
+                f"--max-model-len 4096 --max-lora-rank 64 --host 0.0.0.0 --api-key {VLLM_API_KEY} &"
+            )
+        else:
+            model = _read_env_var(model_var)
+            cmds.append(
+                f"CUDA_VISIBLE_DEVICES={gpu_idx} vllm serve {model} "
+                f"--port {port} --gpu-memory-utilization 0.9 "
+                f"--max-model-len 4096 --host 0.0.0.0 --api-key {VLLM_API_KEY} &"
+            )
     vllm_starts = " ".join(cmds)
     script = f"export HF_HOME=/root/.cache/huggingface && {vllm_starts} wait"
     # Escaped double quotes — the RunPod SDK wraps docker_args in "..." for GraphQL
@@ -177,6 +190,7 @@ def start() -> None:
                 container_disk_in_gb=100,
                 ports=",".join(f"{p}/http" for _, _, _, p, _ in SERVICES),
                 docker_args=_build_startup_cmd(),
+                env={"HF_TOKEN": _read_env_var("HF_TOKEN")},
             )
             used_gpu = gpu
             print(f"  Created: {pod['id']}")


### PR DESCRIPTION
## Summary

- Replace the fine-tuned model GPU slot in `pod start` with `meta-llama/Meta-Llama-3.1-8B-Instruct` + DPO LoRA adapter (`jadshaker/tutorbot-dpo-models`) instead of DeepSeek
- `HF_TOKEN` is now passed as a RunPod pod env var for authenticated HF downloads

## Changes

- `commands/pod.py`: `_build_startup_cmd()` special-cases the fine-tuned slot — downloads adapter + base model via `hf download`, then serves with `--enable-lora --max-lora-rank 64`
- `.env.example`: added `HF_TOKEN`, `FINE_TUNED_BASE_MODEL`, `FINE_TUNED_ADAPTER_REPO`, `FINE_TUNED_ADAPTER_NAME`; updated `FINE_TUNED_MODEL_NAME=dpo-8b`

## Test plan

- [x] `python3.14 cli.py clean` passes
- [x] `python3.14 cli.py pod start` creates pod and all 3 ports become ready
- [x] Port 8001 responds with `tutorbot` model via `/v1/models`
- [x] Chat completions work against the fine-tuned model

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)