### PR TITLE
Host online: Qdrant Cloud, custom domain, HTTPS, deploy pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,8 +55,8 @@ INTENT_CLASSIFIER_LLM_MAX_TOKENS=50
 
 # Vector Cache / Answer Retrieval
 CACHE_TOP_K=5
-QDRANT_HOST=qdrant
-QDRANT_PORT=6333
+QDRANT_CLUSTER_ENDPOINT=https://<your-cluster-id>.cloud.qdrant.io
+QDRANT_API_KEY=your_qdrant_api_key
 
 # Confidence Thresholds (4-tier routing)
 CONFIDENCE_TIER_1=0.85

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to VPS
 on:
   push:
     branches:
-      - host-online
+      - main
 
 jobs:
   deploy:
@@ -17,5 +17,5 @@ jobs:
           key: ${{ secrets.VPS_SSH_KEY }}
           script: |
             cd ~/Lebanese-High-School-AI-Math-Tutor
-            git pull origin host-online
+            git pull origin main
             docker compose up -d --build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,21 @@
+name: Deploy to VPS
+
+on:
+  push:
+    branches:
+      - host-online
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: root
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: |
+            cd ~/Lebanese-High-School-AI-Math-Tutor
+            git pull origin host-online
+            docker compose up -d --build

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,3 @@
+lebanese-high-school-math-tutor.com, www.lebanese-high-school-math-tutor.com {
+    reverse_proxy frontend:80
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,29 +11,11 @@ services:
       - .env
       - path: .env.dev
         required: false
-    environment:
-      - QDRANT_HOST=qdrant
-      - QDRANT_PORT=6333
     command: uvicorn src.main:app --host 0.0.0.0 --port 8000 --reload --no-access-log
-    depends_on:
-      - qdrant
     volumes:
       - ./.logs:/app/logs
     networks:
       - math-tutor-network
-
-  # Qdrant Vector Database
-  qdrant:
-    image: qdrant/qdrant:latest
-    container_name: math-tutor-qdrant
-    ports:
-      - '6333:6333'
-      - '6334:6334'
-    volumes:
-      - qdrant-data:/qdrant/storage
-    networks:
-      - math-tutor-network
-    restart: unless-stopped
 
   # Math Atelier - Custom React frontend
   frontend:
@@ -90,4 +72,3 @@ networks:
 volumes:
   prometheus-data:
   grafana-data:
-  qdrant-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,24 @@ services:
       - math-tutor-network
     restart: unless-stopped
 
+  # Caddy - Reverse proxy + automatic HTTPS (Let's Encrypt)
+  caddy:
+    image: caddy:2-alpine
+    container_name: math-tutor-caddy
+    ports:
+      - '80:80'
+      - '443:443'
+      - '443:443/udp'
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+      - caddy-data:/data
+      - caddy-config:/config
+    depends_on:
+      - frontend
+    networks:
+      - math-tutor-network
+    restart: unless-stopped
+
   # Prometheus - Metrics collection
   prometheus:
     image: prom/prometheus:latest
@@ -72,3 +90,5 @@ networks:
 volumes:
   prometheus-data:
   grafana-data:
+  caddy-data:
+  caddy-config:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "axios": "^1.7.7",
-        "cytoscape": "^3.30.2",
+        "cytoscape": "^3.33.3",
         "framer-motion": "^11.3.28",
         "katex": "^0.16.11",
         "lucide-react": "^1.14.0",
@@ -1722,9 +1722,9 @@
       "license": "MIT"
     },
     "node_modules/cytoscape": {
-      "version": "3.33.2",
-      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
-      "integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.3.tgz",
+      "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "axios": "^1.7.7",
-    "cytoscape": "^3.30.2",
+    "cytoscape": "^3.33.3",
     "framer-motion": "^11.3.28",
     "katex": "^0.16.11",
     "lucide-react": "^1.14.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { AnimatePresence, motion } from 'framer-motion'
 import { useEffect, useState } from 'react'
 import type { Attachment } from './api/types'
+import { uuid } from './utils/uuid'
 import { useConversationStore } from './hooks/useConversationStore'
 import { useGraph } from './hooks/useGraph'
 import { useHealth } from './hooks/useHealth'
@@ -66,7 +67,7 @@ export default function App() {
         filename: string
       }
       const attachment: Attachment = {
-        id: crypto.randomUUID(),
+        id: uuid(),
         name: filename,
         type: 'image',
         mimeType,

--- a/frontend/src/components/InputBar.tsx
+++ b/frontend/src/components/InputBar.tsx
@@ -1,6 +1,7 @@
 import { FileText, Image, Paperclip, Send, X } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { Attachment } from '../api/types'
+import { uuid } from '../utils/uuid'
 
 const MAX_ATTACHMENTS = 5
 const MAX_TEXT_BYTES = 200_000 // 200 KB cap for text files
@@ -115,7 +116,7 @@ export function InputBar({ onSend, disabled, pendingAttachment, onClearPendingAt
     for (const file of toProcess) {
       const type = fileType(file)
       const base: Omit<Attachment, 'dataUrl' | 'textContent'> = {
-        id: crypto.randomUUID(),
+        id: uuid(),
         name: file.name,
         type,
         mimeType: file.type,

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react'
 import { fetchSessions, sendChatMessage } from '../api/client'
 import type { ChatApiMessage, Message } from '../api/types'
+import { uuid } from '../utils/uuid'
 
 const LOADING_ID = '__loading__'
 
@@ -40,7 +41,7 @@ export function useChat() {
       if (!text.trim() || isLoading) return
 
       const userMsg: Message = {
-        id: crypto.randomUUID(),
+        id: uuid(),
         role: 'user',
         content: text.trim(),
         timestamp: new Date(),
@@ -62,7 +63,7 @@ export function useChat() {
         const reply = await sendChatMessage(newHistory)
 
         const assistantMsg: Message = {
-          id: crypto.randomUUID(),
+          id: uuid(),
           role: 'assistant',
           content: reply,
           timestamp: new Date(),
@@ -78,7 +79,7 @@ export function useChat() {
         }
       } catch {
         const errorMsg: Message = {
-          id: crypto.randomUUID(),
+          id: uuid(),
           role: 'assistant',
           content: 'Something went wrong connecting to the tutor. Please try again.',
           timestamp: new Date(),

--- a/frontend/src/hooks/useConversationStore.ts
+++ b/frontend/src/hooks/useConversationStore.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { fetchSessions, sendChatMessage } from '../api/client'
 import type { Attachment, ChatApiMessage, Message } from '../api/types'
+import { uuid } from '../utils/uuid'
 
 /** Build the text sent to the API, appending attachment context the backend can use. */
 function buildApiText(text: string, attachments?: Attachment[]): string {
@@ -115,7 +116,7 @@ export function useConversationStore() {
   }, [])
 
   const createConversation = useCallback((): string => {
-    const id = crypto.randomUUID()
+    const id = uuid()
     const now = new Date().toISOString()
     const conv: Conversation = {
       id, title: 'New Conversation', messages: [],
@@ -220,7 +221,7 @@ export function useConversationStore() {
     const isFirst = baseMessages.length === 0
 
     const userMsg: Message = {
-      id: crypto.randomUUID(), role: 'user',
+      id: uuid(), role: 'user',
       content: text.trim(), timestamp: new Date(),
       attachments,
     }
@@ -246,7 +247,7 @@ export function useConversationStore() {
       const reply = await sendChatMessage(newHistory)
 
       const assistantMsg: Message = {
-        id: crypto.randomUUID(), role: 'assistant',
+        id: uuid(), role: 'assistant',
         content: reply, timestamp: new Date(),
       }
       const finalMessages = [...baseMessages, userMsg, assistantMsg]
@@ -262,7 +263,7 @@ export function useConversationStore() {
       if (isFirst) resolveSession(convId, text.trim())
     } catch {
       const errMsg: Message = {
-        id: crypto.randomUUID(), role: 'assistant',
+        id: uuid(), role: 'assistant',
         content: 'Could not reach the tutor. Please check the backend is running and try again.',
         timestamp: new Date(), error: true,
       }

--- a/frontend/src/hooks/useGraph.ts
+++ b/frontend/src/hooks/useGraph.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { buildWsUrl, fetchGraphTree, fetchSessionState } from '../api/client'
 import type { GraphEvent, GraphTree } from '../api/types'
+import { uuid } from '../utils/uuid'
 
 const MAX_EVENTS = 20
 
@@ -23,7 +24,7 @@ export function useGraph(sessionId: string | null) {
 
   const pushEvent = useCallback((event: GraphEvent) => {
     setEvents((prev) => [
-      { ...event, id: crypto.randomUUID() },
+      { ...event, id: uuid() },
       ...prev.slice(0, MAX_EVENTS - 1),
     ])
   }, [])

--- a/frontend/src/utils/uuid.ts
+++ b/frontend/src/utils/uuid.ts
@@ -1,0 +1,13 @@
+/**
+ * UUID v4 using crypto.getRandomValues(), which works in both HTTP and HTTPS
+ * contexts. crypto.randomUUID() is restricted to secure contexts in Firefox,
+ * causing silent failures when accessed over plain HTTP (e.g. on a VPS).
+ */
+export function uuid(): string {
+  const b = new Uint8Array(16)
+  crypto.getRandomValues(b)
+  b[6] = (b[6] & 0x0f) | 0x40
+  b[8] = (b[8] & 0x3f) | 0x80
+  const h = Array.from(b, (x) => x.toString(16).padStart(2, '0')).join('')
+  return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20)}`
+}

--- a/src/config.py
+++ b/src/config.py
@@ -58,9 +58,8 @@ class Config:
     # === Qdrant ===
 
     class QDRANT:
-        HOST = os.environ["QDRANT_HOST"]
-        PORT = int(os.getenv("QDRANT_PORT", "6333"))
-        GRPC_PORT = int(os.getenv("QDRANT_GRPC_PORT", "6334"))
+        URL = os.environ["QDRANT_CLUSTER_ENDPOINT"]
+        API_KEY = os.environ["QDRANT_API_KEY"]
 
     class COLLECTIONS:
         QUESTIONS = "questions"

--- a/src/main.py
+++ b/src/main.py
@@ -140,10 +140,8 @@ async def lifespan(app: FastAPI):
 
     # Initialize Qdrant
     qdrant_client = AsyncQdrantClient(
-        host=Config.QDRANT.HOST,
-        port=Config.QDRANT.PORT,
-        grpc_port=Config.QDRANT.GRPC_PORT,
-        prefer_grpc=True,
+        url=Config.QDRANT.URL,
+        api_key=Config.QDRANT.API_KEY,
     )
     await vector_cache.initialize(qdrant_client)
 


### PR DESCRIPTION
## Summary

- **Qdrant Cloud migration**: Remove local Qdrant container, switch `AsyncQdrantClient` to use `QDRANT_CLUSTER_ENDPOINT` + `QDRANT_API_KEY`
- **Custom domain + HTTPS**: Add Caddy reverse proxy with auto-provisioned Let's Encrypt certificates for `lebanese-high-school-math-tutor.com`
- **Fix messages disappearing over HTTP**: Replace all `crypto.randomUUID()` calls with a `uuid()` helper using `crypto.getRandomValues()` — `randomUUID` requires HTTPS in Firefox, causing silent crashes on plain HTTP
- **GitHub Actions deploy**: Auto-deploy to Hostinger VPS on push to `main` via SSH

🤖 Generated with [Claude Code](https://claude.com/claude-code)