### PR TITLE
Fix CI/CD workflows: deploy pipeline and Qdrant Cloud migration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,8 @@ jobs:
             set_env QDRANT_CLUSTER_ENDPOINT "$QDRANT_CLUSTER_ENDPOINT"
             set_env QDRANT_API_KEY "$QDRANT_API_KEY"
 
-            git pull origin main
+            git fetch origin main
+            git reset --hard origin/main
             docker compose up -d --build
         env:
           QDRANT_CLUSTER_ENDPOINT: ${{ secrets.QDRANT_CLUSTER_ENDPOINT }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,25 @@ jobs:
           host: ${{ secrets.VPS_HOST }}
           username: root
           key: ${{ secrets.VPS_SSH_KEY }}
+          envs: QDRANT_CLUSTER_ENDPOINT,QDRANT_API_KEY
           script: |
+            set -e
             cd ~/Lebanese-High-School-AI-Math-Tutor
+
+            # Sync secrets from GitHub into .env
+            set_env() {
+              local key=$1 val=$2
+              if grep -q "^${key}=" .env 2>/dev/null; then
+                sed -i "s|^${key}=.*|${key}=${val}|" .env
+              else
+                echo "${key}=${val}" >> .env
+              fi
+            }
+            set_env QDRANT_CLUSTER_ENDPOINT "$QDRANT_CLUSTER_ENDPOINT"
+            set_env QDRANT_API_KEY "$QDRANT_API_KEY"
+
             git pull origin main
             docker compose up -d --build
+        env:
+          QDRANT_CLUSTER_ENDPOINT: ${{ secrets.QDRANT_CLUSTER_ENDPOINT }}
+          QDRANT_API_KEY: ${{ secrets.QDRANT_API_KEY }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,6 +30,8 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
+          QDRANT_CLUSTER_ENDPOINT: ${{ secrets.QDRANT_CLUSTER_ENDPOINT }}
+          QDRANT_API_KEY: ${{ secrets.QDRANT_API_KEY }}
         run: |
           cat > .env << EOF
           OPENAI_API_KEY=$OPENAI_API_KEY
@@ -67,8 +69,8 @@ jobs:
           INTENT_CLASSIFIER_LLM_MAX_TOKENS=50
 
           CACHE_TOP_K=5
-          QDRANT_HOST=qdrant
-          QDRANT_PORT=6333
+          QDRANT_CLUSTER_ENDPOINT=$QDRANT_CLUSTER_ENDPOINT
+          QDRANT_API_KEY=$QDRANT_API_KEY
 
           CONFIDENCE_TIER_1=0.85
           CONFIDENCE_TIER_2=0.70


### PR DESCRIPTION
## Summary

- **Deploy workflow**: Replace `git pull` with `git fetch + git reset --hard origin/main` to avoid divergent branch errors on the VPS
- **Deploy workflow**: Inject `QDRANT_CLUSTER_ENDPOINT` and `QDRANT_API_KEY` from GitHub Secrets into the VPS `.env` on every deploy
- **Run-tests workflow**: Switch from local Qdrant container (`QDRANT_HOST`/`QDRANT_PORT`) to Qdrant Cloud credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)